### PR TITLE
Backward compatibility with the Spring Framework 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.antkorwin</groupId>
     <artifactId>ioutils</artifactId>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.4</version>
     <packaging>jar</packaging>
 
     <name>IO-Utils Library</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.antkorwin</groupId>
     <artifactId>ioutils</artifactId>
-    <version>0.3</version>
+    <version>0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>IO-Utils Library</name>

--- a/src/main/java/com/antkorwin/ioutils/multipartfile/FileResponse.java
+++ b/src/main/java/com/antkorwin/ioutils/multipartfile/FileResponse.java
@@ -12,7 +12,6 @@ import com.antkorwin.ioutils.error.InternalException;
 import com.antkorwin.throwable.functions.ThrowableSupplier;
 import org.apache.commons.io.IOUtils;
 
-import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
@@ -30,7 +29,7 @@ public class FileResponse {
 	private String filename;
 	private String mimeType;
 	private HttpServletResponse response;
-	private ContentDisposition contentDisposition;
+	private String contentDisposition;
 	private HttpStatus responseStatus;
 
 	public static FileResponse builder() {
@@ -52,7 +51,7 @@ public class FileResponse {
 
 		// content-disposition
 		if (contentDisposition != null) {
-			response.setHeader(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString());
+			response.setHeader(HttpHeaders.CONTENT_DISPOSITION, contentDisposition);
 		}
 
 		// filename
@@ -106,13 +105,8 @@ public class FileResponse {
 		return this;
 	}
 
-	public FileResponse contentDisposition(ContentDisposition contentDisposition) {
-		this.contentDisposition = contentDisposition;
-		return this;
-	}
-
 	public FileResponse contentDisposition(String contentDisposition) {
-		this.contentDisposition = ContentDisposition.parse(contentDisposition);
+		this.contentDisposition = contentDisposition;
 		return this;
 	}
 

--- a/src/test/java/com/antkorwin/ioutils/multipartfile/FileResponseTest.java
+++ b/src/test/java/com/antkorwin/ioutils/multipartfile/FileResponseTest.java
@@ -29,7 +29,7 @@ class FileResponseTest {
 		FileResponse.builder()
 		            .file(() -> stream)
 		            .filename(filename)
-		            .contentDisposition(contentDisposition)
+		            .contentDisposition(contentDisposition.toString())
 		            .mimeType(mimeType)
 		            .response(mockResponse)
 		            .build();


### PR DESCRIPTION
remove the using of ContentDisposition class from Spring5, use string instead of ContentDisposition.