### PR TITLE
Remove unused files after GC collect references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.antkorwin</groupId>
     <artifactId>ioutils</artifactId>
-    <version>0.6</version>
+    <version>0.7</version>
     <packaging>jar</packaging>
 
     <name>IO-Utils Library</name>
@@ -165,6 +165,13 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
             <version>2.2.3.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.antkorwin</groupId>
+            <artifactId>common-utils</artifactId>
+            <version>1.0</version>
             <scope>test</scope>
         </dependency>
         <!-- TEST -->

--- a/src/main/java/com/antkorwin/ioutils/TempFile.java
+++ b/src/main/java/com/antkorwin/ioutils/TempFile.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 
+import com.antkorwin.ioutils.temp.TempFileReaper;
 import com.antkorwin.throwable.functions.ThrowableSupplier;
 import com.antkorwin.throwable.functions.ThrowableWrapper;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,8 @@ import org.apache.commons.io.IOUtils;
 @RequiredArgsConstructor
 public class TempFile {
 
+	private static final TempFileReaper tempFileReaper = new TempFileReaper();
+
 	/**
 	 * create a temporary file from InputStream
 	 *
@@ -31,6 +34,7 @@ public class TempFile {
 		return ThrowableWrapper.get(() -> {
 			final File tempFile = File.createTempFile("ioutils-", "." + extension);
 			tempFile.deleteOnExit();
+			tempFileReaper.deleteWhenUnused(tempFile);
 			try (InputStream inputStream = inputStreamSupplier.get();
 			     FileOutputStream out = new FileOutputStream(tempFile)) {
 				// copy data from stream to file
@@ -73,18 +77,6 @@ public class TempFile {
 	}
 
 	/**
-	 * see {@link TempFile#createEmpty()} method
-	 */
-	@Deprecated
-	public static File create() {
-		return ThrowableWrapper.get(() -> {
-			final File tempFile = File.createTempFile("ioutils-", ".tmp");
-			tempFile.deleteOnExit();
-			return tempFile;
-		});
-	}
-
-	/**
 	 * Create an empty temporary file
 	 *
 	 * @return created file
@@ -93,6 +85,7 @@ public class TempFile {
 		return ThrowableWrapper.get(() -> {
 			final File tempFile = File.createTempFile("ioutils-", ".tmp");
 			tempFile.deleteOnExit();
+			tempFileReaper.deleteWhenUnused(tempFile);
 			return tempFile;
 		});
 	}

--- a/src/main/java/com/antkorwin/ioutils/temp/TempFileReaper.java
+++ b/src/main/java/com/antkorwin/ioutils/temp/TempFileReaper.java
@@ -1,0 +1,72 @@
+package com.antkorwin.ioutils.temp;
+
+
+import java.io.File;
+import java.lang.ref.ReferenceQueue;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Delete unused files after GC collect the references.
+ *
+ * @author Anatoliy Korovin
+ */
+public class TempFileReaper {
+
+	private TempFileReaperThread reaperThread;
+	private ReferenceQueue<Object> referenceQueue = new ReferenceQueue<>();
+	private Set<TempFileReference> references = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+
+	/**
+	 * Remove a file from disk after all references to this file will be collected by GC
+	 *
+	 * @param file temporary file
+	 */
+	public void deleteWhenUnused(File file) {
+
+		// collect all references
+		references.add(new TempFileReference(file, referenceQueue));
+
+		// run the thread to delete unused files
+		if (reaperThread == null) {
+			synchronized (this) {
+				if (reaperThread == null) {
+					reaperThread = new TempFileReaperThread();
+					reaperThread.start();
+				}
+			}
+		}
+	}
+
+	/**
+	 * This thread processing unused files
+	 */
+	class TempFileReaperThread extends Thread {
+
+		public TempFileReaperThread() {
+			super("TempFileReaper");
+			setDaemon(true);
+		}
+
+		@Override
+		public void run() {
+			while (references.size() > 0) {
+				try {
+					// wait for a new unused file reference
+					TempFileReference unusedReference = (TempFileReference) referenceQueue.remove();
+					references.remove(unusedReference);
+					// delete file
+					unusedReference.delete();
+					unusedReference.clear();
+				} catch (InterruptedException e) {
+					// TODO: use the Slf4j in this library and send an error message in logs here
+					continue;
+				}
+			}
+			reaperThread = null;
+		}
+	}
+
+}

--- a/src/main/java/com/antkorwin/ioutils/temp/TempFileReference.java
+++ b/src/main/java/com/antkorwin/ioutils/temp/TempFileReference.java
@@ -1,0 +1,38 @@
+package com.antkorwin.ioutils.temp;
+
+import java.io.File;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+
+
+/**
+ * Phantom reference to the temporary file
+ *
+ * @author Anatoliy Korovin
+ */
+class TempFileReference extends PhantomReference<Object> {
+
+	private final String path;
+
+	TempFileReference(File file, ReferenceQueue<? super Object> queue) {
+		super(file, queue);
+		this.path = file.getPath();
+	}
+
+	/**
+	 * Delete a file from disk
+	 *
+	 * @return true if successful
+	 */
+	boolean delete() {
+		try {
+			File file = new File(path);
+			if (file == null || !file.exists()) {
+				return true;
+			}
+			return file.delete();
+		} catch (Exception ex) {
+			return false;
+		}
+	}
+}

--- a/src/main/java/com/antkorwin/ioutils/temp/TempFileReference.java
+++ b/src/main/java/com/antkorwin/ioutils/temp/TempFileReference.java
@@ -32,6 +32,7 @@ class TempFileReference extends PhantomReference<Object> {
 			}
 			return file.delete();
 		} catch (Exception ex) {
+			//TODO: add logging in this lib
 			return false;
 		}
 	}

--- a/src/test/java/com/antkorwin/ioutils/TempFileTest.java
+++ b/src/test/java/com/antkorwin/ioutils/TempFileTest.java
@@ -14,16 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TempFileTest {
 
 	@Test
-	void createEmptyOld() throws IOException {
-		// Act
-		File file = TempFile.create();
-		// Assert
-		assertThat(file.exists()).isTrue();
-		String content = FileUtils.readFileToString(file);
-		assertThat(content).isEmpty();
-	}
-
-	@Test
 	void createEmpty() throws IOException {
 		// Act
 		File file = TempFile.createEmpty();

--- a/src/test/java/com/antkorwin/ioutils/temp/TempFileReaperTest.java
+++ b/src/test/java/com/antkorwin/ioutils/temp/TempFileReaperTest.java
@@ -1,0 +1,38 @@
+package com.antkorwin.ioutils.temp;
+
+import java.io.File;
+
+import com.antkorwin.commonutils.gc.GcUtils;
+import com.antkorwin.ioutils.TempFile;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TempFileReaperTest {
+
+	@Test
+	void deleteAfterGc() {
+		// Arrange
+		File tmp = TempFile.createFromString("ABC");
+		String path = tmp.getPath();
+		// Act
+		tmp = null;
+		GcUtils.fullFinalization();
+		// Assert
+		File file = new File(path);
+		assertThat(file).doesNotExist();
+	}
+
+	@Test
+	void deleteEmptyAfterGc() {
+		// Arrange
+		File tmp = TempFile.createEmpty();
+		String path = tmp.getPath();
+		// Act
+		tmp = null;
+		GcUtils.fullFinalization();
+		// Assert
+		File file = new File(path);
+		assertThat(file).doesNotExist();
+	}
+}


### PR DESCRIPTION
remove unused temporary files after GC collect all references

and remove deprecated method `create` empty